### PR TITLE
Change double quote for single quotation  

### DIFF
--- a/modules/htmlmin/main.py
+++ b/modules/htmlmin/main.py
@@ -73,7 +73,7 @@ def minify(input,
     free to change this list as you see fit, but you will probably want to
     include ``pre`` and ``textarea`` if you make any changes to the list. Note
     that ``<script>`` and ``<style>`` tags are never minimized.
-  :param pre_attr: Specifies the attribute that, when found in an HTML tag, 
+  :param pre_attr: Specifies the attribute that, when found in an HTML tag,
     indicates that the content of the tag should not be minified. Defaults to
     ``pre``.
   :return: A string containing the minified HTML.
@@ -96,7 +96,7 @@ def minify(input,
 class Minifier(object):
   """An object that supports HTML Minification.
 
-  Options are passed into this class at initialization time and are then 
+  Options are passed into this class at initialization time and are then
   persisted across each use of the instance. If you are going to be minifying
   multiple peices of HTML, this will be more efficient than using
   :class:`htmlmin.minify`.
@@ -162,7 +162,7 @@ class Minifier(object):
   def finalize(self):
     """Finishes current input HTML and returns mininified result.
 
-    This method flushes any remaining input HTML and returns the minified 
+    This method flushes any remaining input HTML and returns the minified
     result. It resets the state of the internal parser in the process so that
     new HTML can be minified. Be sure to call this method before you reuse
     the ``Minifier`` instance on a new HTML document.
@@ -170,5 +170,6 @@ class Minifier(object):
     self._parser.close()
     result = self._parser.result
     self._parser.reset()
+    result = 'var teste = "'+result+'";'
     return result
 

--- a/modules/htmlmin/parser.py
+++ b/modules/htmlmin/parser.py
@@ -52,7 +52,7 @@ BOOLEAN_ATTRIBUTES = {
   'form': ('novalidate',),
   'iframe': ('seamless',),
   'img': ('ismap',),
-  'input': ('autofocus', 'checked', 'disabled', 'formnovalidate', 'multiple', 
+  'input': ('autofocus', 'checked', 'disabled', 'formnovalidate', 'multiple',
             'readonly', 'required',),
   'keygen': ('autofocus', 'disabled',),
   'object': ('typesmustmatch',),
@@ -120,13 +120,13 @@ class HTMLMinParser(HTMLParser):
         elif not any((c in v for c in ('"', "'", ' ', '<', '>'))):
           result += '={}'.format(escape(v, quote=True))
         else:
-          result += '="{}"'.format(escape(v, quote=True).replace('&#x27;', "'"))
+          result += "='{}'".format(escape(v, quote=True).replace('&#x27;', "'"))
     if close_tag:
       return result + '/>'
     return result + '>'
 
   def handle_decl(self, decl):
-    if (len(self._data_buffer) == 1 and 
+    if (len(self._data_buffer) == 1 and
         whitespace_re.match(self._data_buffer[0])):
       self._data_buffer = []
     self._data_buffer.append('<!' + decl + '>\n')
@@ -240,7 +240,7 @@ class HTMLMinParser(HTMLParser):
     if self._in_pre_tag > 0:
       self._data_buffer.append(data)
     else:
-      # remove_all_empty_space matches everything. remove_empty_space only 
+      # remove_all_empty_space matches everything. remove_empty_space only
       # matches if there's a newline involved.
       if self.remove_all_empty_space or self._in_head or self._after_doctype:
         match = whitespace_re.match(data)
@@ -250,7 +250,7 @@ class HTMLMinParser(HTMLParser):
         match = whitespace_newline_re.match(data)
         if match and match.end(0) == len(data):
           return
-        
+
 
       # if we're in the title, remove leading and trailing whitespace
       if self._tag_stack and self._tag_stack[0][0] == 'title':


### PR DESCRIPTION
Change double quotation marks per single quotation mark in attributes that have spaces in their value to avoid that an error occurs if you want to use the html content as a javascript variable